### PR TITLE
Fix WASM airport lookup test for updated data

### DIFF
--- a/crates/rs1090-wasm/tests/src/tests/test_utils.test.ts
+++ b/crates/rs1090-wasm/tests/src/tests/test_utils.test.ts
@@ -14,7 +14,7 @@ describe("rs1090 utils", () => {
 
   test("airports", () => {
     const a = airport_information("Paris");
-    expect(a.length).toBe(7);
-    expect(a[0].icao).toBe("LFPG");
+    expect(a.length).toBe(11);
+    expect(a.some((airport: { icao?: string }) => airport.icao === "LFPG")).toBe(true);
   });
 });


### PR DESCRIPTION
The airport dataset now contains 11 records matching Paris, and result ordering is not a stable API guarantee. Update the expected count and assert that LFPG is present without relying on its position. Local wasm-pack build and all 19 Jest tests pass.