### PR TITLE
Make Docker cache export non-fatal

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,4 +80,4 @@ jobs:
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true


### PR DESCRIPTION
The Docker image build and registry push succeed, but the GitHub Actions cache exporter can fail with `failed to reserve cache`. Make cache export non-fatal so cache service/quota issues cannot fail an otherwise successful image build.