### PR TITLE
fix(rs1090): reconnect to beast feeds with backoff instead of spinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soapysdr",
+ "socket2",
  "ssh2-config",
  "tokio",
  "tokio-tungstenite",

--- a/crates/rs1090/Cargo.toml
+++ b/crates/rs1090/Cargo.toml
@@ -61,6 +61,7 @@ tracing-subscriber = "0.3.22"
 zip = { version = "8", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+socket2 = "0.6.3"
 tokio = { version = "1.52.1", features = ["full"] }
 tokio-tungstenite = "0.28.0"
 

--- a/crates/rs1090/src/source/beast.rs
+++ b/crates/rs1090/src/source/beast.rs
@@ -2,9 +2,11 @@ use async_stream::stream;
 use futures::stream::SplitStream;
 use futures_util::pin_mut;
 use futures_util::stream::{Stream, StreamExt};
+use socket2::{SockRef, TcpKeepalive};
 use tokio::io::AsyncReadExt;
 use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::mpsc;
+use tokio::time::{sleep, timeout};
 #[cfg(feature = "ssh")]
 use tokio_tungstenite::client_async;
 use tokio_tungstenite::connect_async;
@@ -13,10 +15,12 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::{
     tungstenite::protocol::Message, MaybeTlsStream, WebSocketStream,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use std::collections::HashSet;
+use std::fmt;
 use std::io;
+use std::time::Duration;
 
 use crate::decode::time::{now_in_ns, since_today_to_nanos};
 use crate::prelude::*;
@@ -57,6 +61,42 @@ pub enum BeastSource {
     TunnelledWebsocket(super::ssh::TunnelledWebsocket),
 }
 
+impl fmt::Display for BeastSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BeastSource::Tcp(address) => write!(f, "tcp://{address}"),
+            BeastSource::Udp(address) => write!(f, "udp://{address}"),
+            BeastSource::Websocket(address) => write!(f, "{address}"),
+            #[cfg(feature = "ssh")]
+            BeastSource::TunnelledTcp(tunnel) => write!(
+                f,
+                "tcp://{}:{} (via {})",
+                tunnel.address, tunnel.port, tunnel.jump
+            ),
+            #[cfg(feature = "ssh")]
+            BeastSource::TunnelledWebsocket(tunnel) => {
+                write!(f, "{} (via {})", tunnel.url, tunnel.jump)
+            }
+        }
+    }
+}
+
+/// First reconnection delay, doubled after each failed attempt.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// Give up on a connection that stays silent this long. A peer can vanish
+/// without a TCP reset (a Tailscale node going to sleep, for instance) and
+/// a plain read would then block forever. Keep this generous, a quiet
+/// receiver in the middle of the night may legitimately see no traffic for
+/// a while.
+const READ_TIMEOUT: Duration = Duration::from_secs(300);
+/// TCP keepalive settings for plain TCP feeds. The kernel starts probing
+/// after [`KEEPALIVE_TIME`] of silence and gives up after a handful of
+/// unanswered probes, which detects a dead peer much faster than
+/// [`READ_TIMEOUT`].
+const KEEPALIVE_TIME: Duration = Duration::from_secs(15);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+
 pub async fn next_msg(mut stream: DataSource) -> impl Stream<Item = Vec<u8>> {
     // Initialize a HashSet to check for valid message types
     let valid_msg_types: HashSet<u8> =
@@ -69,64 +109,101 @@ pub async fn next_msg(mut stream: DataSource) -> impl Stream<Item = Vec<u8>> {
         let mut buffer = [0u8; 1024];
         let bytes_read = match &mut stream {
             DataSource::Tcp(tcp_stream) => {
-                match tcp_stream.read(&mut buffer).await {
-                    Ok(0) => break, // Connection closed by peer
-                    Ok(n) => n,
-                    Err(e) => {
+                match timeout(READ_TIMEOUT, tcp_stream.read(&mut buffer)).await {
+                    Ok(Ok(0)) => {
+                        info!("Connection closed by peer");
+                        break;
+                    }
+                    Ok(Ok(n)) => n,
+                    Ok(Err(e)) => {
                         error!("Error reading from socket: {}", e);
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("No data received for {READ_TIMEOUT:?}, assuming the connection is dead");
                         break;
                     }
                 }
             }
             DataSource::Udp(udp_socket) => {
-                match udp_socket.recv_from(&mut buffer).await {
-                    Ok((n, _)) => n,
-                    Err(e) => {
+                match timeout(READ_TIMEOUT, udp_socket.recv_from(&mut buffer))
+                    .await
+                {
+                    Ok(Ok((n, _))) => n,
+                    Ok(Err(e)) => {
                         error!("Error reading from socket: {}", e);
+                        break;
+                    }
+                    // A UDP socket never reports a dead sender. Dropping it
+                    // after a long silence sends us back through `connect`,
+                    // which also gives TCP another chance when the UDP socket
+                    // was only a fallback.
+                    Err(_) => {
+                        warn!("No data received for {READ_TIMEOUT:?}, re-opening the socket");
                         break;
                     }
                 }
             }
             DataSource::Websocket(ws_receive) => {
-                match ws_receive.next().await {
-                    Some(Ok(Message::Binary(data))) => {
+                match timeout(READ_TIMEOUT, ws_receive.next()).await {
+                    Ok(Some(Ok(Message::Binary(data)))) => {
                         debug!("Received {:?}", data);
                         let len = data.len().min(buffer.len());
                         buffer[..len].copy_from_slice(&data[..len]);
                         len
                     }
-                    _ => {
-                        error!("Error reading from websocket");
+                    // pings, pongs and text frames carry no Beast data
+                    Ok(Some(Ok(_))) => 0,
+                    Ok(Some(Err(e))) => {
+                        error!("Error reading from websocket: {}", e);
+                        break;
+                    }
+                    Ok(None) => {
+                        info!("Websocket closed by peer");
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("No data received for {READ_TIMEOUT:?}, assuming the connection is dead");
                         break;
                     }
                 }
             }
             #[cfg(feature = "ssh")]
             DataSource::TunnelledTcp(tunnel_rx) => {
-                match tunnel_rx.recv().await {
-                    Ok(Some(makiko::TunnelEvent::Data(data))) => {
+                match timeout(READ_TIMEOUT, tunnel_rx.recv()).await {
+                    Ok(Ok(Some(makiko::TunnelEvent::Data(data)))) => {
                         debug!("Received {:?}", data);
                         let len = data.len().min(buffer.len());
                         buffer[..len].copy_from_slice(&data[..len]);
                         len
                     }
-                    _ => {
+                    Ok(_) => {
                         error!("Error reading from tunnel");
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("No data received for {READ_TIMEOUT:?}, assuming the tunnel is dead");
                         break;
                     }
                 }
             }
             #[cfg(feature = "ssh")]
             DataSource::TunnelledWebSocket(tunnel_rx) => {
-                match tunnel_rx.next().await {
-                    Some(Ok(Message::Binary(data))) => {
+                match timeout(READ_TIMEOUT, tunnel_rx.next()).await {
+                    Ok(Some(Ok(Message::Binary(data)))) => {
                         debug!("Received {:?}", data);
                         let len = data.len().min(buffer.len());
                         buffer[..len].copy_from_slice(&data[..len]);
                         len
                     }
-                    _ => {
+                    // pings, pongs and text frames carry no Beast data
+                    Ok(Some(Ok(_))) => 0,
+                    Ok(_) => {
                         error!("Error reading from tunnel");
+                        break;
+                    }
+                    Err(_) => {
+                        warn!("No data received for {READ_TIMEOUT:?}, assuming the tunnel is dead");
                         break;
                     }
                 }
@@ -192,16 +269,20 @@ pub async fn next_msg(mut stream: DataSource) -> impl Stream<Item = Vec<u8>> {
     }
 }
 
-pub async fn receiver(
-    address: BeastSource,
-    tx: mpsc::Sender<TimedMessage>,
-    serial: u64,
-    name: Option<String>,
-) -> io::Result<()> {
-    let msg_stream = match address {
-        BeastSource::Tcp(address) => match TcpStream::connect(&address).await {
+/// Open one connection, without retrying.
+async fn connect(address: &BeastSource) -> io::Result<DataSource> {
+    let source = match address {
+        BeastSource::Tcp(address) => match TcpStream::connect(address).await {
             Ok(stream) => {
                 info!("Connected to TCP stream: {}", address);
+                let keepalive = TcpKeepalive::new()
+                    .with_time(KEEPALIVE_TIME)
+                    .with_interval(KEEPALIVE_INTERVAL);
+                if let Err(e) =
+                    SockRef::from(&stream).set_tcp_keepalive(&keepalive)
+                {
+                    warn!("Failed to enable TCP keepalive: {}", e);
+                }
                 DataSource::Tcp(stream)
             }
             Err(error) => {
@@ -210,52 +291,94 @@ pub async fn receiver(
                     address,
                     error.to_string()
                 );
-                DataSource::Udp(UdpSocket::bind(&address).await?)
+                DataSource::Udp(UdpSocket::bind(address).await?)
             }
         },
         BeastSource::Udp(address) => {
-            DataSource::Udp(UdpSocket::bind(&address).await?)
+            DataSource::Udp(UdpSocket::bind(address).await?)
         }
         BeastSource::Websocket(address) => {
             info!("Connecting to websocket: {}", address);
             let (stream, _) =
-                connect_async(&address).await.map_err(io::Error::other)?;
+                connect_async(address).await.map_err(io::Error::other)?;
             info!("Connected to websocket: {}", address);
             let (_, rx) = stream.split();
             DataSource::Websocket(rx)
         }
         #[cfg(feature = "ssh")]
         BeastSource::TunnelledTcp(tunnel) => {
-            let tunnel_rx = tunnel.connect().await.expect("Failed to connect");
+            let tunnel_rx = tunnel.connect().await.map_err(io::Error::other)?;
             DataSource::TunnelledTcp(tunnel_rx)
         }
         #[cfg(feature = "ssh")]
         BeastSource::TunnelledWebsocket(tunnel) => {
-            let stream = tunnel.connect().await.expect("Failed to connect");
-            let url =
-                tunnel.url.into_client_request().expect("Invalid request");
+            let stream = tunnel.connect().await.map_err(io::Error::other)?;
+            let url = tunnel
+                .url
+                .clone()
+                .into_client_request()
+                .map_err(io::Error::other)?;
 
             // Now perform the handshake using client_async, which accepts an already connected stream.
             let (ws_stream, _) =
-                client_async(url, stream).await.expect("Failed to connect");
+                client_async(url, stream).await.map_err(io::Error::other)?;
 
             let (_, rx) = ws_stream.split();
             DataSource::TunnelledWebSocket(rx)
         }
     };
+    Ok(source)
+}
 
-    let msg_stream = beast::next_msg(msg_stream).await;
-    pin_mut!(msg_stream); // needed for iteration
-    'receive: loop {
+/// Receive Beast messages from `address` and forward them to `tx`.
+///
+/// Whenever the connection cannot be opened, gets closed by the peer, or
+/// stays silent for five minutes, it is opened again after an exponential
+/// backoff capped at 30 seconds. The function only returns once the
+/// receiving end of `tx` has been dropped.
+pub async fn receiver(
+    address: BeastSource,
+    tx: mpsc::Sender<TimedMessage>,
+    serial: u64,
+    name: Option<String>,
+) -> io::Result<()> {
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        let source = match connect(&address).await {
+            Ok(source) => source,
+            Err(error) => {
+                warn!(
+                    "Failed to connect to {address} ({error}), retrying in {backoff:?}"
+                );
+                sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        let msg_stream = next_msg(source).await;
+        pin_mut!(msg_stream);
+        let mut received_any = false;
         while let Some(msg) = msg_stream.next().await {
+            if !received_any {
+                // Only reset the backoff once the new connection has
+                // actually delivered something
+                received_any = true;
+                backoff = INITIAL_BACKOFF;
+            }
             let tmsg = process_radarcape(&msg, serial, name.clone());
             info!("Received {}", tmsg);
             if tx.send(tmsg).await.is_err() {
-                break 'receive;
+                // The consumer is gone, so there is no point reconnecting
+                return Ok(());
             }
         }
+
+        warn!("Connection to {address} lost, reconnecting in {backoff:?}");
+        sleep(backoff).await;
+        backoff = (backoff * 2).min(MAX_BACKOFF);
     }
-    Ok(())
 }
 
 fn process_radarcape(
@@ -310,5 +433,60 @@ fn process_radarcape(
         message: None,
         metadata: vec![metadata],
         decode_time: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    /// A 23-byte Mode-S long frame whose last byte is `marker`, so the test
+    /// can tell which connection a message came from.
+    fn long_frame(marker: u8) -> Vec<u8> {
+        let mut msg = vec![0x1a, 0x33];
+        msg.extend_from_slice(&[0, 0, 0, 0, 0, 0]); // MLAT timestamp
+        msg.push(0x80); // signal level
+        msg.extend_from_slice(&[0x8d; 13]); // 14-byte frame
+        msg.push(marker);
+        msg
+    }
+
+    #[tokio::test]
+    async fn reconnects_after_peer_closes_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap().to_string();
+
+        // Serve two connections in a row, one frame each, then hang up
+        let server = tokio::spawn(async move {
+            for marker in [1u8, 2u8] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                socket.write_all(&long_frame(marker)).await.unwrap();
+                socket.shutdown().await.unwrap();
+                drop(socket);
+            }
+        });
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let client =
+            tokio::spawn(receiver(BeastSource::Tcp(address), tx, 0, None));
+
+        let first = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first message before timeout")
+            .expect("first message");
+        assert_eq!(first.frame.last(), Some(&1));
+
+        // The server only sends one frame per connection, so a second
+        // message proves the client reconnected
+        let second = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("second message before timeout")
+            .expect("second message");
+        assert_eq!(second.frame.last(), Some(&2));
+
+        server.await.unwrap();
+        client.abort();
     }
 }


### PR DESCRIPTION
When a Beast peer drops the connection, `beast::receiver` keeps polling the finished stream in a hot loop. That pins one core per dead feed and the shutdown branch of the surrounding `select!` never gets to run. Nothing tries to reconnect either. A peer that disappears without a TCP reset, which is what happens when a Tailscale node goes to sleep, leaves the read blocked forever.

The receiver now reconnects with exponential backoff, 1s up to 30s, and resets it once the new connection delivers a message. Plain TCP feeds get kernel keepalive so a vanished peer surfaces as a read error within about a minute. Five minutes of silence on any source counts as dead. For a UDP socket that was only a fallback this also gives TCP another try. Startup no longer gives up when the peer or the VPN is not up yet, and the SSH tunnel paths return errors instead of panicking so they take part in the retry.

Test: a local listener drops the client after one frame, and the client comes back and receives the next one.