### PR TITLE
fix(jet1090): fill in aircraft count and last timestamp on /sensors

### DIFF
--- a/crates/jet1090/src/sensor.rs
+++ b/crates/jet1090/src/sensor.rs
@@ -20,9 +20,11 @@ pub struct Sensor {
     pub reference: Option<Position>,
     /// An (optional) position altitude (in m, WGS84 height)
     pub altitude: Option<f64>,
-    /// How many aircraft are seen by the sensor
+    /// Number of aircraft the sensor currently sees, computed on `/sensors`
+    /// requests
     pub aircraft_count: u64,
-    /// The timestamp for the last seen message
+    /// System timestamp in seconds of the last message from the sensor,
+    /// computed on `/sensors` requests
     pub last_timestamp: u64,
 }
 

--- a/crates/jet1090/src/web.rs
+++ b/crates/jet1090/src/web.rs
@@ -6,10 +6,12 @@ use axum::response::{Html, IntoResponse, Json, Response};
 use axum::routing::get;
 use axum::Router;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 
-use crate::snapshot::Snapshot;
+use crate::sensor::Sensor;
+use crate::snapshot::{Snapshot, StateVectors};
 use crate::SharedState;
 
 /// Information required to ask for a trajectory
@@ -69,7 +71,36 @@ async fn track(
 
 /// Returns decoding information about all sensors
 async fn sensors(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
-    Json(shared.sensors.clone())
+    let state_vectors = shared.state_vectors.read().await;
+    Json(sensor_stats(&shared.sensors, &state_vectors))
+}
+
+/// Fill in the aircraft count and last timestamp of each sensor.
+///
+/// A sensor counts an aircraft when it received that aircraft's latest
+/// message. Counts across sensors can therefore add up to more than the
+/// number of aircraft, since several sensors may receive the same message.
+fn sensor_stats(
+    sensors: &BTreeMap<u64, Sensor>,
+    state_vectors: &BTreeMap<String, StateVectors>,
+) -> BTreeMap<u64, Sensor> {
+    let mut sensors = sensors.clone();
+    let mut seen = HashSet::new();
+    for sv in state_vectors.values() {
+        // Metadata can list the same sensor several times for one aircraft,
+        // which must still only count once
+        seen.clear();
+        for meta in &sv.cur.metadata {
+            if let Some(sensor) = sensors.get_mut(&meta.serial) {
+                if seen.insert(meta.serial) {
+                    sensor.aircraft_count += 1;
+                }
+                sensor.last_timestamp =
+                    sensor.last_timestamp.max(meta.system_timestamp as u64);
+            }
+        }
+    }
+    sensors
 }
 
 /// Returns a list of potential airports matching the query string


### PR DESCRIPTION
`/sensors` has always returned zero for `aircraft_count` and `last_timestamp`. Both fields are set when the sensor list is built at startup and nothing writes to them afterwards, since the shared sensor map is read-only by design.