### PR TITLE
feat(jet1090): add interactive source health dashboard

### DIFF
--- a/crates/jet1090/src/health.rs
+++ b/crates/jet1090/src/health.rs
@@ -1,0 +1,261 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt::Write;
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Local};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+
+const MAX_EVENTS: usize = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceStatus {
+    Connecting,
+    Healthy,
+    Reconnecting,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Severity {
+    Warning,
+    Error,
+}
+
+impl Severity {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Warning => "WARN",
+            Self::Error => "ERROR",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HealthEvent {
+    pub timestamp: DateTime<Local>,
+    pub severity: Severity,
+    pub source: String,
+    pub message: String,
+    pub occurrences: u32,
+}
+
+#[derive(Debug, Default)]
+pub struct HealthState {
+    pub sources: BTreeMap<String, SourceStatus>,
+    pub events: VecDeque<HealthEvent>,
+    pub unread_errors: usize,
+}
+
+pub type SharedHealth = Arc<Mutex<HealthState>>;
+
+pub fn new_health() -> SharedHealth {
+    Arc::new(Mutex::new(HealthState::default()))
+}
+
+pub fn register_source(health: &SharedHealth, source: String) {
+    let mut health = health.lock().expect("health state lock poisoned");
+    health
+        .sources
+        .entry(source)
+        .or_insert(SourceStatus::Connecting);
+}
+
+pub fn set_source_status(
+    health: &SharedHealth,
+    source: &str,
+    status: SourceStatus,
+) {
+    let mut health = health.lock().expect("health state lock poisoned");
+    health.sources.insert(source.to_string(), status);
+}
+
+pub fn mark_events_read(health: &SharedHealth) {
+    health
+        .lock()
+        .expect("health state lock poisoned")
+        .unread_errors = 0;
+}
+
+/// Print the retained operational events after the alternate screen is restored.
+/// This preserves diagnostics when a graceful TUI shutdown prevents opening the
+/// in-app error overlay.
+pub fn print_report(health: &SharedHealth) {
+    let health = health.lock().expect("health state lock poisoned");
+    if health.events.is_empty() {
+        return;
+    }
+
+    eprintln!("jet1090 recent warnings and errors:");
+    for event in &health.events {
+        let repeats = if event.occurrences > 1 {
+            format!(" (×{})", event.occurrences)
+        } else {
+            String::new()
+        };
+        eprintln!(
+            "{} {} {}: {}{}",
+            event.timestamp.format("%H:%M:%S"),
+            event.severity.label(),
+            event.source,
+            event.message,
+            repeats,
+        );
+    }
+}
+
+fn record_event(
+    health: &SharedHealth,
+    severity: Severity,
+    source: String,
+    message: String,
+) {
+    let mut health = health.lock().expect("health state lock poisoned");
+    if let Some(status) = health.sources.get_mut(&source) {
+        *status = match severity {
+            Severity::Warning => SourceStatus::Reconnecting,
+            Severity::Error => SourceStatus::Failed,
+        };
+    }
+    if let Some(last) = health.events.back_mut() {
+        if last.severity == severity
+            && last.source == source
+            && last.message == message
+        {
+            last.timestamp = Local::now();
+            last.occurrences += 1;
+            if severity == Severity::Error {
+                health.unread_errors += 1;
+            }
+            return;
+        }
+    }
+
+    if health.events.len() == MAX_EVENTS {
+        health.events.pop_front();
+    }
+    health.events.push_back(HealthEvent {
+        timestamp: Local::now(),
+        severity,
+        source,
+        message,
+        occurrences: 1,
+    });
+    if severity == Severity::Error {
+        health.unread_errors += 1;
+    }
+}
+
+pub struct UiEventLayer {
+    health: SharedHealth,
+}
+
+impl UiEventLayer {
+    pub fn new(health: SharedHealth) -> Self {
+        Self { health }
+    }
+}
+
+impl<S> Layer<S> for UiEventLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+        let severity = match *event.metadata().level() {
+            Level::ERROR => Severity::Error,
+            Level::WARN => Severity::Warning,
+            _ => return,
+        };
+        let mut visitor = EventVisitor::default();
+        event.record(&mut visitor);
+        let source = visitor
+            .source
+            .unwrap_or_else(|| event.metadata().target().to_string());
+        let mut message = if visitor.message.is_empty() {
+            event.metadata().name().to_string()
+        } else {
+            visitor.message
+        };
+        if let Some(error) = visitor.error {
+            message.push_str(&format!(": {error}"));
+        }
+        record_event(&self.health, severity, source, message);
+    }
+}
+
+#[derive(Default)]
+struct EventVisitor {
+    source: Option<String>,
+    message: String,
+    error: Option<String>,
+}
+
+impl Visit for EventVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "source" {
+            self.source =
+                Some(format!("{value:?}").trim_matches('"').to_string());
+        } else if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+            self.message = self.message.trim_matches('"').to_string();
+        } else if field.name() == "error" {
+            self.error =
+                Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "source" {
+            self.source = Some(value.to_string());
+        } else if field.name() == "message" {
+            self.message = value.to_string();
+        } else if field.name() == "error" {
+            self.error = Some(value.to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retains_a_bounded_event_history() {
+        let health = new_health();
+        for index in 0..=MAX_EVENTS {
+            record_event(
+                &health,
+                Severity::Warning,
+                "test".to_string(),
+                index.to_string(),
+            );
+        }
+        let health = health.lock().unwrap();
+        assert_eq!(health.events.len(), MAX_EVENTS);
+        assert_eq!(health.events.front().unwrap().message, "1");
+    }
+
+    #[test]
+    fn coalesces_repeated_errors_and_marks_source_failed() {
+        let health = new_health();
+        register_source(&health, "Delft".to_string());
+        record_event(
+            &health,
+            Severity::Error,
+            "Delft".to_string(),
+            "connection lost".to_string(),
+        );
+        record_event(
+            &health,
+            Severity::Error,
+            "Delft".to_string(),
+            "connection lost".to_string(),
+        );
+        let health = health.lock().unwrap();
+        assert_eq!(health.events.len(), 1);
+        assert_eq!(health.events[0].occurrences, 2);
+        assert_eq!(health.unread_errors, 2);
+        assert_eq!(health.sources["Delft"], SourceStatus::Failed);
+    }
+}

--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -2,6 +2,7 @@
 
 mod dedup;
 mod filters;
+mod health;
 mod sensor;
 mod shell;
 mod snapshot;
@@ -14,6 +15,7 @@ mod web;
 use crate::tui::Event;
 use crate::util::expanduser;
 use crate::web::serve_web_api;
+use crate::{health::SharedHealth, health::SourceStatus};
 use clap::{Command, CommandFactory, Parser, ValueHint};
 use clap_complete::{generate, Generator};
 use crossterm::event::KeyCode;
@@ -300,24 +302,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     options.sources.append(&mut cli_options.sources);
 
-    // example: RUST_LOG=rs1090=DEBUG
-    let env_filter = EnvFilter::from_default_env();
-
-    let subscriber = tracing_subscriber::registry().with(env_filter);
-    match options.log_file.as_deref() {
-        Some("-") if !cli_options.interactive => {
-            // when it's interactive, logs will disrupt the display
-            subscriber.with(fmt::layer().pretty()).init();
-        }
-        Some(log_file) if log_file != "-" => {
-            let file = std::fs::File::create(log_file).unwrap_or_else(|_| {
-                panic!("fail to create log file: {log_file}")
-            });
-            let file_layer = fmt::layer().with_writer(file).with_ansi(false);
-            subscriber.with(file_layer).init();
-        }
-        _ => {
-            subscriber.init(); // no logging
+    // Capture operational warnings by default; RUST_LOG can raise or lower verbosity.
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("warn"));
+    let health = health::new_health();
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(health::UiEventLayer::new(health.clone()));
+    if options.interactive {
+        // Writing tracing events to stdout or stderr corrupts the alternate TUI screen.
+        subscriber.init();
+    } else {
+        match options.log_file.as_deref() {
+            Some("-") => subscriber.with(fmt::layer().pretty()).init(),
+            Some(log_file) => {
+                let file =
+                    std::fs::File::create(log_file).unwrap_or_else(|_| {
+                        panic!("fail to create log file: {log_file}")
+                    });
+                let file_layer =
+                    fmt::layer().with_writer(file).with_ansi(false);
+                subscriber.with(file_layer).init();
+            }
+            None => subscriber.init(),
         }
     }
 
@@ -397,32 +404,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut aircraft: BTreeMap<ICAO, AircraftState> = BTreeMap::new();
 
-    // Initialize terminal
-    let terminal = if options.interactive {
-        Some(tui::init()?)
-    } else {
-        None
-    };
-
-    // Ensure terminal is restored on panic
-    let _terminal_guard = if terminal.is_some() {
-        Some(tui::TerminalGuard)
-    } else {
-        None
-    };
-
-    let width = if let Some(terminal) = &terminal {
-        terminal.size()?.width
-    } else {
-        0
-    };
-
-    let mut events = if terminal.is_some() {
-        Some(tui::EventHandler::new(width))
-    } else {
-        None
-    };
-
     const SENSOR_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
     let mut references = BTreeMap::<u64, Option<Position>>::new();
     let mut sensors = BTreeMap::<u64, Sensor>::new();
@@ -459,11 +440,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Create shared state accessible by all tasks
-    let shared = Arc::new(SharedState::new(sensors));
+    let shared = Arc::new(SharedState::new(sensors, health.clone()));
     let shared_dec = shared.clone();
     let shared_web = shared.clone();
     let shared_exp = shared.clone();
     let mut quit_rx = shared_dec.quit_tx.subscribe();
+    for source in &options.sources {
+        let serial = source.serial();
+        let source_label = source
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("source-{serial:016x}"));
+        health::register_source(&health, source_label);
+    }
+
+    // Do not enter the alternate screen until source discovery is complete:
+    // discovery can wait on remote services and would otherwise leave a blank TUI.
+    let terminal = if options.interactive {
+        Some(tui::init()?)
+    } else {
+        None
+    };
+    let _terminal_guard = if terminal.is_some() {
+        Some(tui::TerminalGuard)
+    } else {
+        None
+    };
+    let width = match &terminal {
+        Some(terminal) => terminal.size()?.width,
+        None => 0,
+    };
+    let mut events = terminal.is_some().then(|| tui::EventHandler::new(width));
 
     // Handle signals (SIGINT, SIGTERM, SIGHUP) to ensure terminal restoration
     if terminal.is_some() {
@@ -529,40 +536,70 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         search_query: "".to_string(),
         interactive_expire: options.interactive_expire.unwrap_or(30),
         flags: options.flags,
+        show_errors: false,
+        error_scroll: 0,
     }));
 
+    let mut tui_handle = None;
     if let Some(mut terminal) = terminal {
+        // Render synchronously once so a working table is visible before the
+        // input task receives its first periodic tick.
+        {
+            let mut app = app_tui.lock().await;
+            let state_vectors = shared.state_vectors.read().await;
+            terminal.draw(|frame| {
+                table::build_table(frame, &mut app, &shared, &state_vectors)
+            })?;
+        }
+
         let app_tui_task = app_tui.clone();
         let shared_tui = shared.clone();
         let mut events =
             events.take().expect("event handler in interactive mode");
-        tokio::spawn(async move {
+        tui_handle = Some(tokio::spawn(async move {
             loop {
-                if let Ok(event) = events.next().await {
-                    update(&mut app_tui_task.lock().await, event, &shared_tui)?;
+                let event = match events.next().await {
+                    Ok(event) => event,
+                    Err(error) => {
+                        error!(error = %error, "Interactive event handler failed");
+                        shared_tui.request_quit();
+                        break;
+                    }
+                };
+                if let Err(error) =
+                    update(&mut app_tui_task.lock().await, event, &shared_tui)
+                {
+                    error!(error = %error, "Interactive update failed");
+                    shared_tui.request_quit();
+                    break;
                 }
                 let mut app = app_tui_task.lock().await;
                 if shared_tui.should_quit.load(Ordering::Relaxed) {
                     break;
                 }
                 if shared_tui.should_clear.swap(false, Ordering::Relaxed) {
-                    terminal.clear()?;
+                    // Clearing only removes incidental stdout from SDR backends.
+                    // A terminal that cannot be cleared can still render normally.
+                    if let Err(error) = terminal.clear() {
+                        warn!(error = %error, "Interactive terminal clear failed; continuing");
+                    }
                 }
-                // Acquire read lock on state_vectors before drawing
-                // This allows concurrent reads by TUI and Web API
                 let state_vectors = shared_tui.state_vectors.read().await;
-                terminal.draw(|frame| {
+                if let Err(error) = terminal.draw(|frame| {
                     table::build_table(
                         frame,
                         &mut app,
                         &shared_tui,
                         &state_vectors,
                     )
-                })?;
-                drop(state_vectors); // Release read lock
+                }) {
+                    error!(error = %error, "Interactive terminal draw failed");
+                    shared_tui.request_quit();
+                    break;
+                }
             }
             tui::restore()
-        });
+        }));
     }
 
     if let Some(minutes) = options.history_expire {
@@ -607,8 +644,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let serial = source.serial();
         let tx_copy = tx.clone();
         let source_name = source.name.clone();
+        let source_label = source_name
+            .clone()
+            .unwrap_or_else(|| format!("source-{serial:016x}"));
+        health::register_source(&health, source_label.clone());
+        health::set_source_status(
+            &health,
+            &source_label,
+            SourceStatus::Healthy,
+        );
         let shutdown_rx = shutdown_tx.subscribe();
-        let handle = source.receiver(tx_copy, serial, source_name, shutdown_rx);
+        let handle = source.receiver(
+            tx_copy,
+            serial,
+            source_name,
+            shutdown_rx,
+            health.clone(),
+        );
         source_handles.push(handle);
     }
 
@@ -676,12 +728,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             break;
         };
         if first_msg {
-            // This workaround results from soapysdr writing directly on stdout.
-            // The best thing would be to not write to stdout in the first
-            // place. A better workaround would be to condition that clear to
-            // the first message received from rtlsdr.
-
-            shared_dec.should_clear.store(true, Ordering::Relaxed);
+            // Do not clear the terminal here: crossterm's clear path queries
+            // cursor position and can fail in otherwise functional terminals.
             first_msg = false;
         }
 
@@ -810,13 +858,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Signal all source tasks to shut down
+    // Signal all source tasks and the TUI to shut down.
+    shared_dec.request_quit();
     let _ = shutdown_tx.send(());
 
     // Wait for all source tasks to finish with timeout
     let timeout = Duration::from_secs(2);
     for handle in source_handles {
         let _ = tokio::time::timeout(timeout, handle).await;
+    }
+    if let Some(handle) = tui_handle {
+        let _ = tokio::time::timeout(timeout, handle).await;
+    }
+    if options.interactive {
+        tui::restore().ok();
+        health::print_report(&health);
     }
 
     Ok(())
@@ -867,6 +923,8 @@ pub struct Jet1090 {
     search_query: String,
     interactive_expire: u64,
     flags: bool,
+    show_errors: bool,
+    error_scroll: usize,
 }
 
 /// Shared state that multiple tasks need to access
@@ -882,10 +940,12 @@ pub struct SharedState {
     quit_tx: watch::Sender<bool>,
     /// Clear screen flag - lock-free atomic
     should_clear: Arc<AtomicBool>,
+    /// Recent operational events and source health for the interactive UI
+    health: SharedHealth,
 }
 
 impl SharedState {
-    fn new(sensors: BTreeMap<u64, Sensor>) -> Self {
+    fn new(sensors: BTreeMap<u64, Sensor>, health: SharedHealth) -> Self {
         let (quit_tx, _quit_rx) = watch::channel(false);
 
         Self {
@@ -894,6 +954,7 @@ impl SharedState {
             should_quit: Arc::new(AtomicBool::new(false)),
             quit_tx,
             should_clear: Arc::new(AtomicBool::new(false)),
+            health,
         }
     }
 
@@ -936,7 +997,8 @@ fn update(
                 (false, Char('j')) | (_, Down) => jet1090.next(),
                 (false, Char('k')) | (_, Up) => jet1090.previous(),
                 (false, Char('g')) | (_, PageUp) | (_, Home) => jet1090.home(),
-                (false, Char('q')) | (false, Esc) => shared.request_quit(),
+                (false, Char('q')) => shared.request_quit(),
+                (false, Esc) if !jet1090.show_errors => shared.request_quit(),
                 (false, Char('a')) => jet1090.sort_key = SortKey::ALTITUDE,
                 (false, Char('c')) => jet1090.sort_key = SortKey::CALLSIGN,
                 (false, Char('v')) => jet1090.sort_key = SortKey::VRATE,
@@ -945,6 +1007,28 @@ fn update(
                 (false, Char('l')) => jet1090.sort_key = SortKey::LAST,
                 (false, Char('-')) => jet1090.sort_asc = !jet1090.sort_asc,
                 (false, Char('/')) => jet1090.is_search_mode = true,
+                (false, Char('e')) => {
+                    jet1090.show_errors = !jet1090.show_errors;
+                    if jet1090.show_errors {
+                        health::mark_events_read(&shared.health);
+                    }
+                }
+                (false, Char('E')) => {
+                    jet1090.show_errors = false;
+                    health::mark_events_read(&shared.health);
+                }
+                (false, Char('J')) if jet1090.show_errors => {
+                    jet1090.error_scroll =
+                        jet1090.error_scroll.saturating_add(1)
+                }
+                (false, Char('K')) if jet1090.show_errors => {
+                    jet1090.error_scroll =
+                        jet1090.error_scroll.saturating_sub(1)
+                }
+                (false, Esc) if jet1090.show_errors => {
+                    jet1090.show_errors = false;
+                    health::mark_events_read(&shared.health);
+                }
                 _ => {}
             }
         }

--- a/crates/jet1090/src/source.rs
+++ b/crates/jet1090/src/source.rs
@@ -49,6 +49,8 @@ use tokio::sync::mpsc::Sender;
 use tracing::error;
 use url::Url;
 
+use crate::health::{self, SharedHealth, SourceStatus};
+
 #[cfg(feature = "sdr")]
 const MODES_FREQ: f64 = 1.09e9;
 #[cfg(feature = "sdr")]
@@ -667,7 +669,11 @@ impl Source {
         serial: u64,
         name: Option<String>,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+        health: SharedHealth,
     ) -> tokio::task::JoinHandle<()> {
+        let source_label = name
+            .clone()
+            .unwrap_or_else(|| format!("source-{serial:016x}"));
         match &self.address {
             #[cfg(feature = "rtlsdr")]
             Address::Rtlsdr(path) => {
@@ -1044,11 +1050,22 @@ impl Source {
                     },
                     _ => unreachable!(),
                 };
+                let source_health = health.clone();
+                let status_health = health.clone();
+                let status_label = source_label.clone();
                 tokio::spawn(async move {
                     tokio::select! {
-                        result = beast::receiver(server_address, tx, serial, name) => {
+                        result = beast::receiver(server_address, tx, serial, name, move |status| {
+                            let status = match status {
+                                beast::ConnectionStatus::Connecting => SourceStatus::Connecting,
+                                beast::ConnectionStatus::Healthy => SourceStatus::Healthy,
+                                beast::ConnectionStatus::Reconnecting => SourceStatus::Reconnecting,
+                            };
+                            health::set_source_status(&status_health, &status_label, status);
+                        }) => {
                             if let Err(e) = result {
-                                error!("{}", e.to_string());
+                                health::set_source_status(&source_health, &source_label, SourceStatus::Failed);
+                                error!(source = source_label, error = %e, "Beast receiver stopped");
                             }
                         }
                         _ = shutdown_rx.recv() => {

--- a/crates/jet1090/src/table.rs
+++ b/crates/jet1090/src/table.rs
@@ -8,11 +8,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use style::palette::tailwind;
 use tokio::sync::RwLockReadGuard;
 
+use crate::health::{Severity, SourceStatus};
 use crate::snapshot::{Snapshot, StateVectors};
 use crate::{Jet1090, SharedState, SortKey};
 
 const INFO_TEXT: &str =
-    "(Esc/Q) quit | (↑/K) up | (↓/J) down | (⤒/G) top | (/) search";
+    "(Esc/Q) quit | (↑/K) up | (↓/J) down | (⤒/G) top | (/) search | (E) errors";
 
 /**
  * Rendering of the table in interactive mode
@@ -20,7 +21,7 @@ const INFO_TEXT: &str =
 pub fn build_table(
     frame: &mut Frame,
     app: &mut Jet1090,
-    _shared: &SharedState,
+    shared: &SharedState,
     state_vectors: &RwLockReadGuard<'_, BTreeMap<String, StateVectors>>,
 ) {
     let now = SystemTime::now()
@@ -247,6 +248,7 @@ pub fn build_table(
         .map(|c| c.constraint())
         .collect::<Vec<Constraint>>();
 
+    let health_title = source_health_title(shared);
     let table = Table::new(rows, constraints)
         .column_spacing(2)
         .header(
@@ -261,9 +263,14 @@ pub fn build_table(
         )
         .block(
             Block::default()
-                .title_bottom(format!("jet1090 ({size} aircraft)",))
-                .title_alignment(Alignment::Right)
-                .title_style(Style::new().blue().bold())
+                .title_bottom(health_title)
+                .title_bottom(
+                    Line::from(Span::styled(
+                        format!("jet1090 ({size} aircraft) "),
+                        Style::new().blue().bold(),
+                    ))
+                    .alignment(Alignment::Right),
+                )
                 .padding(Padding::symmetric(1, 0))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded),
@@ -291,25 +298,154 @@ pub fn build_table(
         &mut app.scroll_state,
     );
 
-    let area = rects[1];
-    if app.is_search_mode {
-        frame.render_widget(
-            Paragraph::new(Line::from(format!(
-                "Search (Esc to cancel, Enter to lock): {}",
-                app.search_query
-            )))
-            .style(Style::new().fg(colors.row_fg).bg(colors.buffer_bg))
-            .left_aligned(),
-            area,
-        );
+    let controls_area = rects[1];
+    let controls = if app.is_search_mode {
+        Line::from(format!(
+            "Search (Esc to cancel, Enter to lock): {}",
+            app.search_query
+        ))
     } else {
-        frame.render_widget(
-            Paragraph::new(Line::from(INFO_TEXT))
-                .style(Style::new().fg(colors.row_fg).bg(colors.buffer_bg))
-                .centered(),
-            area,
-        );
+        Line::from(INFO_TEXT)
+    };
+    frame.render_widget(
+        Paragraph::new(controls)
+            .style(Style::new().fg(colors.row_fg).bg(colors.buffer_bg))
+            .centered(),
+        controls_area,
+    );
+
+    if app.show_errors {
+        render_error_overlay(frame, app, shared);
     }
+}
+
+fn source_health_title(shared: &SharedState) -> Line<'static> {
+    let health = shared.health.lock().expect("health state lock poisoned");
+    let mut healthy = 0;
+    let mut connecting = 0;
+    let mut reconnecting = 0;
+    let mut failed = 0;
+    for status in health.sources.values() {
+        match status {
+            SourceStatus::Healthy => healthy += 1,
+            SourceStatus::Connecting => connecting += 1,
+            SourceStatus::Reconnecting => reconnecting += 1,
+            SourceStatus::Failed => failed += 1,
+        }
+    }
+
+    let mut spans = vec![
+        Span::raw(" "),
+        Span::styled(
+            format!("● {healthy}"),
+            Style::new().fg(tailwind::GREEN.c400),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("○ {connecting}"),
+            Style::new().fg(tailwind::CYAN.c400),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("↻ {reconnecting}"),
+            Style::new().fg(tailwind::YELLOW.c400),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("✕ {failed}"),
+            Style::new().fg(tailwind::RED.c400),
+        ),
+    ];
+    if health.unread_errors > 0 {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            format!("⚠ {}", health.unread_errors),
+            Style::new().fg(tailwind::RED.c400).bold(),
+        ));
+    }
+    Line::from(spans)
+}
+
+fn render_error_overlay(
+    frame: &mut Frame,
+    app: &mut Jet1090,
+    shared: &SharedState,
+) {
+    let health = shared.health.lock().expect("health state lock poisoned");
+    let area = centered_rect(85, 75, frame.area());
+    let height = area.height.saturating_sub(2) as usize;
+    let visible_events = health
+        .events
+        .iter()
+        .rev()
+        .skip(app.error_scroll)
+        .take(height)
+        .cloned()
+        .collect::<Vec<_>>();
+    let event_count = health.events.len();
+    drop(health);
+    let events = visible_events
+        .iter()
+        .map(|event| {
+            let color = match event.severity {
+                Severity::Warning => tailwind::YELLOW.c400,
+                Severity::Error => tailwind::RED.c400,
+            };
+            let repeats = if event.occurrences > 1 {
+                format!(" (×{})", event.occurrences)
+            } else {
+                String::new()
+            };
+            Line::from(vec![
+                Span::styled(
+                    event.timestamp.format("%H:%M:%S").to_string(),
+                    Style::new().fg(tailwind::SLATE.c400),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    event.severity.label(),
+                    Style::new().fg(color).bold(),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    event.source.clone(),
+                    Style::new().fg(tailwind::CYAN.c300),
+                ),
+                Span::raw("  "),
+                Span::raw(format!("{}{}", event.message, repeats)),
+            ])
+        })
+        .collect::<Vec<_>>();
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(events)
+            .block(
+                Block::default()
+                    .title(format!(" Recent errors ({event_count}) "))
+                    .title_style(Style::new().fg(tailwind::RED.c400).bold())
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::new().fg(tailwind::RED.c400)),
+            )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
 }
 
 /**

--- a/crates/jet1090/src/tui.rs
+++ b/crates/jet1090/src/tui.rs
@@ -16,9 +16,7 @@ pub struct TerminalGuard;
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        // TODO define what do to upon panic, but this commented behaviour is
-        // actually not a great idea since the app may still be partially running
-        // let _ = restore();
+        let _ = restore();
     }
 }
 
@@ -27,9 +25,7 @@ pub fn init() -> io::Result<Tui> {
     // Install custom panic hook to restore terminal before displaying panic
     let original_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
-        // TODO define what do to upon panic, but this commented behaviour is
-        // actually not a great idea since the app may still be partially running
-        // let _ = restore();
+        let _ = restore();
         original_hook(panic_info);
     }));
 

--- a/crates/rs1090/src/source/beast.rs
+++ b/crates/rs1090/src/source/beast.rs
@@ -330,24 +330,41 @@ async fn connect(address: &BeastSource) -> io::Result<DataSource> {
     Ok(source)
 }
 
+/// Connection lifecycle events emitted by [`receiver`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConnectionStatus {
+    Connecting,
+    Healthy,
+    Reconnecting,
+}
+
 /// Receive Beast messages from `address` and forward them to `tx`.
 ///
 /// Whenever the connection cannot be opened, gets closed by the peer, or
 /// stays silent for five minutes, it is opened again after an exponential
 /// backoff capped at 30 seconds. The function only returns once the
 /// receiving end of `tx` has been dropped.
-pub async fn receiver(
+pub async fn receiver<F>(
     address: BeastSource,
     tx: mpsc::Sender<TimedMessage>,
     serial: u64,
     name: Option<String>,
-) -> io::Result<()> {
+    on_status: F,
+) -> io::Result<()>
+where
+    F: Fn(ConnectionStatus),
+{
     let mut backoff = INITIAL_BACKOFF;
 
+    on_status(ConnectionStatus::Connecting);
     loop {
         let source = match connect(&address).await {
-            Ok(source) => source,
+            Ok(source) => {
+                on_status(ConnectionStatus::Healthy);
+                source
+            }
             Err(error) => {
+                on_status(ConnectionStatus::Reconnecting);
                 warn!(
                     "Failed to connect to {address} ({error}), retrying in {backoff:?}"
                 );
@@ -375,6 +392,7 @@ pub async fn receiver(
             }
         }
 
+        on_status(ConnectionStatus::Reconnecting);
         warn!("Connection to {address} lost, reconnecting in {backoff:?}");
         sleep(backoff).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -469,8 +487,13 @@ mod tests {
         });
 
         let (tx, mut rx) = mpsc::channel(16);
-        let client =
-            tokio::spawn(receiver(BeastSource::Tcp(address), tx, 0, None));
+        let client = tokio::spawn(receiver(
+            BeastSource::Tcp(address),
+            tx,
+            0,
+            None,
+            |_| {},
+        ));
 
         let first = timeout(Duration::from_secs(5), rx.recv())
             .await

--- a/crates/rs1090/src/source/sero.rs
+++ b/crates/rs1090/src/source/sero.rs
@@ -139,9 +139,11 @@ impl SeroClient {
                     let jump = jump.clone();
                     async move {
                         let tunnel = TunnelledSero { jump };
-                        let stream = tunnel.connect().await;
-                        let wrapped_stream = TokioIo::new(stream);
-                        Ok::<_, std::io::Error>(wrapped_stream)
+                        let stream =
+                            tunnel.connect().await.map_err(|error| {
+                                std::io::Error::other(error.to_string())
+                            })?;
+                        Ok::<_, std::io::Error>(TokioIo::new(stream))
                     }
                 });
                 endpoint.connect_with_connector(connector).await?

--- a/crates/rs1090/src/source/ssh.rs
+++ b/crates/rs1090/src/source/ssh.rs
@@ -14,12 +14,16 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     process::{ChildStdin, ChildStdout, Command},
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 pub static CONNECTION_MAP: Lazy<Arc<Mutex<HashMap<String, Client>>>> =
     Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+/// Prevent concurrent first-time connections from racing before the cache is
+/// populated. This matters when several sources share one ProxyJump host.
+static CONNECTION_SETUP_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 pub struct TunnelledTcp {
     pub address: String,
@@ -42,119 +46,113 @@ async fn authenticate_server(
     mut client_rx: ClientReceiver,
     host: String,
     port: u16,
-) {
-    let mut hosts_path = dirs::home_dir().unwrap();
+) -> Result<(), BoxError> {
+    let mut hosts_path = dirs::home_dir().ok_or_else(|| {
+        BoxError::from("Could not determine the home directory")
+    })?;
     hosts_path.push(".ssh");
     hosts_path.push("known_hosts");
-
-    let hosts_data =
-        std::fs::read(&hosts_path).expect("Could not read known_hosts file");
-
+    let hosts_data = std::fs::read(&hosts_path).map_err(|error| {
+        BoxError::from(format!(
+            "Could not read {}: {error}",
+            hosts_path.display()
+        ))
+    })?;
     let mut hosts_file = makiko::host_file::File::decode(hosts_data.into());
 
     loop {
-        // Wait for the next event.
-        let event = client_rx
-            .recv()
-            .await
-            .expect("Error while receiving client event");
-
-        // Exit the loop when the client has closed.
+        let event = client_rx.recv().await.map_err(|error| {
+            BoxError::from(format!(
+                "Error while receiving SSH client event: {error}"
+            ))
+        })?;
         let Some(event) = event else { break };
 
         if let makiko::ClientEvent::ServerPubkey(pubkey, accept) = event {
-            info!(
-                "Server pubkey type {}, fingerprint {}",
-                pubkey.type_str(),
-                pubkey.fingerprint()
-            );
-
             match hosts_file.match_host_port_key(&host, port, &pubkey) {
-                makiko::host_file::KeyMatch::Accepted(entries) => {
-                    info!("Found the server key in known_hosts file");
-                    for entry in entries.iter() {
-                        info!("At line {}", entry.line());
-                    }
-                    accept.accept();
+                makiko::host_file::KeyMatch::Accepted(_) => accept.accept(),
+                makiko::host_file::KeyMatch::Revoked(_) => {
+                    return Err(BoxError::from(
+                        "The SSH server key was revoked in known_hosts",
+                    ));
                 }
-                makiko::host_file::KeyMatch::Revoked(_entry) => {
-                    panic!("The server key was revoked in known_hosts file");
-                }
-                makiko::host_file::KeyMatch::OtherKeys(entries) => {
-                    warn!("The known_hosts file specifies other keys for this server:");
-                    for entry in entries.iter() {
-                        println!(
-                            "At line {}, pubkey type {}, fingerprint {}",
-                            entry.line(),
-                            entry.pubkey().type_str(),
-                            entry.pubkey().fingerprint()
-                        );
-                    }
-                    panic!("Aborting, you might be target of a man-in-the-middle attack!");
+                makiko::host_file::KeyMatch::OtherKeys(_) => {
+                    return Err(BoxError::from(
+                        "SSH host key differs from known_hosts; refusing connection",
+                    ));
                 }
                 makiko::host_file::KeyMatch::NotFound => {
-                    info!("Did not find any key for this server in known_hosts file, \
-                            adding it to the file");
-
                     accept.accept();
-
                     hosts_file.append_entry(
                         makiko::host_file::File::entry_builder()
                             .host_port(&host, port)
                             .key(pubkey),
                     );
-                    let hosts_data = hosts_file.encode();
-                    std::fs::write(&hosts_path, &hosts_data).expect(
-                        "Could not write the modified known_hosts file",
-                    );
+                    std::fs::write(&hosts_path, hosts_file.encode()).map_err(
+                        |error| {
+                            BoxError::from(format!(
+                                "Could not update {}: {error}",
+                                hosts_path.display()
+                            ))
+                        },
+                    )?;
                 }
             }
         }
     }
+    Ok(())
 }
 
 async fn authenticate_by_private_key(
     client: &Client,
     user: &str,
     privkey: &Privkey,
-) {
+) -> Result<(), BoxError> {
     let pubkey = privkey.pubkey();
     for pubkey_algo in pubkey.algos().iter().copied() {
-        // Check whether this combination of a public key and algorithm would be
-        // acceptable to the server.
         if client
             .check_pubkey(user.to_string(), &pubkey, pubkey_algo)
             .await
-            .expect("Error when checking a public key")
+            .map_err(|error| {
+                BoxError::from(format!(
+                    "Error when checking an SSH public key: {error}"
+                ))
+            })?
         {
-            // Try to authenticate with the private key
-            let auth_res = client
+            match client
                 .auth_pubkey(user.to_string(), privkey.clone(), pubkey_algo)
                 .await
-                .expect("Error when trying to authenticate");
-
-            // Deal with the possible outcomes of public key authentication.
-            match auth_res {
-                makiko::AuthPubkeyResult::Success => {
-                    info!("We have successfully authenticated using a private key");
-                    return;
-                }
+                .map_err(|error| {
+                    BoxError::from(format!(
+                        "Error authenticating with SSH key: {error}"
+                    ))
+                })? {
+                makiko::AuthPubkeyResult::Success => return Ok(()),
                 makiko::AuthPubkeyResult::Failure(failure) => {
-                    info!(
-                        "The server rejected authentication with {pubkey_algo:?}: {failure:?}"
-                    );
+                    info!("The server rejected authentication with {pubkey_algo:?}: {failure:?}");
                 }
             }
         }
     }
-    panic!("The server does not accept the public key");
+    Err(BoxError::from(
+        "The SSH server does not accept the private key",
+    ))
 }
 
-fn get_params() -> SshConfig {
-    let config_path = dirs::home_dir().unwrap().join(".ssh").join("config");
-
-    let err_msg = format!("{config_path:?} does not exist");
-    let mut reader = BufReader::new(File::open(&config_path).expect(&err_msg));
+fn get_params() -> Result<SshConfig, BoxError> {
+    let config_path = dirs::home_dir()
+        .ok_or_else(|| {
+            BoxError::from("Could not determine the home directory")
+        })?
+        .join(".ssh")
+        .join("config");
+    let file = File::open(&config_path).map_err(|error| {
+        BoxError::from(format!(
+            "Could not read {}: {error}",
+            config_path.display()
+        ))
+    })?;
+    let mut reader = BufReader::new(file);
 
     SshConfig::default()
         .parse(
@@ -162,21 +160,24 @@ fn get_params() -> SshConfig {
             ParseRule::ALLOW_UNKNOWN_FIELDS
                 | ParseRule::ALLOW_UNSUPPORTED_FIELDS,
         )
-        .unwrap_or_else(|_| {
-            panic!("Failed to parse configuration file {config_path:?}")
+        .map_err(|error| {
+            BoxError::from(format!(
+                "Failed to parse {}: {error}",
+                config_path.display()
+            ))
         })
 }
 
-fn get_default_username() -> String {
+fn get_default_username() -> Result<String, BoxError> {
     #[cfg(target_os = "windows")]
-    let username = std::env::var("USERNAME").unwrap_or_else(|_| {
-        panic!("Could not determine the current Windows user name")
-    });
+    let username = std::env::var("USERNAME").map_err(|_| {
+        BoxError::from("Could not determine the current Windows user name")
+    })?;
     #[cfg(not(target_os = "windows"))]
-    let username = std::env::var("USER").unwrap_or_else(|_| {
-        panic!("Could not determine the current user name")
-    });
-    username
+    let username = std::env::var("USER").map_err(|_| {
+        BoxError::from("Could not determine the current user name")
+    })?;
+    Ok(username)
 }
 
 enum Io {
@@ -190,32 +191,57 @@ enum Io {
  * and proxy jumps. It also handles authentication using private keys.
  * It returns a Client object that can be used to interact with the server.
  */
-#[async_recursion::async_recursion]
 async fn connect_server(
     server: &str,
     params: &SshConfig,
     connection_map: Arc<Mutex<HashMap<String, Client>>>,
 ) -> Result<Client, BoxError> {
+    let _setup_lock = CONNECTION_SETUP_LOCK.lock().await;
+    connect_server_inner(server, params, connection_map).await
+}
+
+#[async_recursion::async_recursion]
+async fn connect_server_inner(
+    server: &str,
+    params: &SshConfig,
+    connection_map: Arc<Mutex<HashMap<String, Client>>>,
+) -> Result<Client, BoxError> {
+    debug!(server, "Starting SSH connection setup");
     // Check if the server is already connected
     // If so, return the existing connection
     if connection_map.lock().await.contains_key(server) {
         info!("Reusing existing connection to {server}");
-        return Ok(connection_map.lock().await.get(server).unwrap().clone());
+        return connection_map.lock().await.get(server).cloned().ok_or_else(
+            || BoxError::from("SSH connection cache entry disappeared"),
+        );
     }
 
     // Otherwise create a new connection
     let server_params = params.query(server);
-    let hostname = server_params.host_name.unwrap();
+    let hostname = server_params.host_name.ok_or_else(|| {
+        BoxError::from(format!(
+            "No hostname configured for SSH host '{server}'"
+        ))
+    })?;
     let port = server_params.port.unwrap_or(22);
-    let user = server_params.user.unwrap_or(get_default_username());
+    let user = match server_params.user {
+        Some(user) => user,
+        None => get_default_username()?,
+    };
 
-    let io = match server_params.unsupported_fields.get("proxyjump") {
+    // ProxyJump is a parsed ssh2-config field. Reading it from
+    // `unsupported_fields` ignores normal ProxyJump entries and attempts a
+    // direct TCP connection instead.
+    let io = match server_params.proxy_jump.as_ref() {
         None => match server_params.unsupported_fields.get("proxycommand") {
             None => {
                 Io::Tcp(TcpStream::connect((hostname.to_owned(), port)).await?)
             }
             Some(args) => {
-                let mut command = Command::new(args[0].clone());
+                let command_name = args.first().ok_or_else(|| {
+                    BoxError::from("SSH ProxyCommand is empty")
+                })?;
+                let mut command = Command::new(command_name);
                 for arg in args[1..].iter() {
                     let arg = arg
                         // Replace %% with %
@@ -231,14 +257,19 @@ async fn connect_server(
                         .stdin(std::process::Stdio::piped())
                         .stdout(std::process::Stdio::piped())
                         .stderr(std::process::Stdio::piped()),
-                ))
+                )?)
             }
         },
         Some(jump) => {
-            let jump_server = jump.first().expect("No jump host specified");
-            let jump_client =
-                connect_server(jump_server, params, connection_map.clone())
-                    .await?;
+            let jump_server = jump
+                .first()
+                .ok_or_else(|| BoxError::from("No SSH jump host specified"))?;
+            let jump_client = connect_server_inner(
+                jump_server,
+                params,
+                connection_map.clone(),
+            )
+            .await?;
             let channel_config = ChannelConfig::default();
             let origin_addr = ("127.0.0.1".into(), 0);
             let (tunnel, tunnel_rx) = jump_client
@@ -248,43 +279,72 @@ async fn connect_server(
                     origin_addr,
                 )
                 .await
-                .expect("Could not open a tunnel");
+                .map_err(|error| {
+                    BoxError::from(format!(
+                        "Could not open SSH tunnel: {error}"
+                    ))
+                })?;
             Io::Tunnel(TunnelStream::new(tunnel, tunnel_rx))
         }
     };
 
+    debug!(server, hostname, port, "Opening SSH client transport");
     let config = ClientConfig::default();
     let (client, client_rx) = match io {
         Io::Tcp(socket) => {
             let (client, client_rx, client_fut) = Client::open(socket, config)?;
             tokio::spawn(async move {
-                client_fut.await.expect("Error in client future");
+                if let Err(error) = client_fut.await {
+                    warn!("SSH client connection closed: {error}");
+                }
             });
             (client, client_rx)
         }
         Io::Tunnel(io) => {
             let (client, client_rx, client_fut) = Client::open(io, config)?;
             tokio::spawn(async move {
-                client_fut.await.expect("Error in client future");
+                if let Err(error) = client_fut.await {
+                    warn!("SSH client connection closed: {error}");
+                }
             });
             (client, client_rx)
         }
         Io::Proxy(io) => {
             let (client, client_rx, client_fut) = Client::open(io, config)?;
             tokio::spawn(async move {
-                client_fut.await.expect("Error in client future");
+                if let Err(error) = client_fut.await {
+                    warn!("SSH client connection closed: {error}");
+                }
             });
             (client, client_rx)
         }
     };
 
-    tokio::task::spawn(authenticate_server(client_rx, hostname, port));
-
-    let ssh_folder = dirs::home_dir().unwrap().join(".ssh");
-    let mut decoded_privkey = None;
-    let identity_files = server_params.identity_file.unwrap_or_else(|| {
-        vec![ssh_folder.join("id_rsa"), ssh_folder.join("id_ed25519")]
+    tokio::spawn(async move {
+        if let Err(error) = authenticate_server(client_rx, hostname, port).await
+        {
+            warn!("SSH host verification failed: {error}");
+        }
     });
+
+    let ssh_folder = dirs::home_dir()
+        .ok_or_else(|| {
+            BoxError::from("Could not determine the home directory")
+        })?
+        .join(".ssh");
+    debug!(server, "Selecting SSH identity file");
+    let mut decoded_privkey = None;
+    let configured_identity_files =
+        server_params.identity_file.unwrap_or_else(|| {
+            vec![ssh_folder.join("id_rsa"), ssh_folder.join("id_ed25519")]
+        });
+    // OpenSSH's `IdentityFile none` clears inherited identities. ssh2-config
+    // preserves it as a path, so apply the reset before trying keys.
+    let identity_files = configured_identity_files
+        .iter()
+        .rposition(|path| path == std::path::Path::new("none"))
+        .map(|index| configured_identity_files[index + 1..].to_vec())
+        .unwrap_or(configured_identity_files);
     for file in identity_files.iter() {
         let filename = file.as_os_str();
         if let Ok(privkey) = tokio::fs::read(file).await {
@@ -328,9 +388,14 @@ async fn connect_server(
             };
         }
     }
-    let privkey =
-        decoded_privkey.expect("None of the identity files could be decoded");
-    authenticate_by_private_key(&client, &user, &privkey).await;
+    let privkey = decoded_privkey.ok_or_else(|| {
+        BoxError::from(
+            "None of the configured SSH identity files could be decoded",
+        )
+    })?;
+    debug!(server, user, "Authenticating SSH client");
+    authenticate_by_private_key(&client, &user, &privkey).await?;
+    debug!(server, "SSH client authenticated");
 
     connection_map
         .lock()
@@ -342,7 +407,7 @@ async fn connect_server(
 
 impl TunnelledTcp {
     pub async fn connect(&self) -> Result<TunnelReceiver, BoxError> {
-        let params = get_params();
+        let params = get_params()?;
 
         let target_client =
             connect_server(&self.jump, &params, CONNECTION_MAP.clone())
@@ -359,11 +424,14 @@ impl TunnelledTcp {
         let connect_addr = (self.address.to_owned(), self.port);
         let origin_addr = ("0.0.0.0".into(), 0);
 
-        let err_msg = format!("Could not open a tunnel to {connect_addr:?}");
         let (_tunnel, tunnel_rx) = target_client
-            .connect_tunnel(channel_config, connect_addr, origin_addr)
+            .connect_tunnel(channel_config, connect_addr.clone(), origin_addr)
             .await
-            .expect(&err_msg);
+            .map_err(|error| {
+                BoxError::from(format!(
+                    "Could not open a tunnel to {connect_addr:?}: {error}"
+                ))
+            })?;
 
         Ok(tunnel_rx)
     }
@@ -371,7 +439,7 @@ impl TunnelledTcp {
 
 impl TunnelledWebsocket {
     pub async fn connect(&self) -> Result<TunnelStream, BoxError> {
-        let params = get_params();
+        let params = get_params()?;
 
         let target_client =
             connect_server(&self.jump, &params, CONNECTION_MAP.clone())
@@ -388,34 +456,44 @@ impl TunnelledWebsocket {
         let connect_addr = (self.address.to_owned(), self.port);
         let origin_addr = ("0.0.0.0".into(), 0);
 
-        let err_msg = format!("Could not open a tunnel to {connect_addr:?}");
         let (tunnel, tunnel_rx) = target_client
-            .connect_tunnel(channel_config, connect_addr, origin_addr)
+            .connect_tunnel(channel_config, connect_addr.clone(), origin_addr)
             .await
-            .expect(&err_msg);
+            .map_err(|error| {
+                BoxError::from(format!(
+                    "Could not open a tunnel to {connect_addr:?}: {error}"
+                ))
+            })?;
 
         Ok(TunnelStream::new(tunnel, tunnel_rx))
     }
 }
 
 impl TunnelledSero {
-    pub async fn connect(&self) -> TunnelStream {
-        let params = get_params();
-
+    pub async fn connect(&self) -> Result<TunnelStream, BoxError> {
+        let params = get_params()?;
         let target_client =
             connect_server(&self.jump, &params, CONNECTION_MAP.clone())
                 .await
-                .expect("Could not connect to jump host");
+                .map_err(|error| {
+                    BoxError::from(format!(
+                        "Could not connect to Sero jump host {}: {error}",
+                        self.jump
+                    ))
+                })?;
         let channel_config = makiko::ChannelConfig::default();
         let connect_addr = ("api.secureadsb.com".to_string(), 4201);
         let origin_addr = ("0.0.0.0".into(), 0);
-
         let (tunnel, tunnel_rx) = target_client
             .connect_tunnel(channel_config, connect_addr, origin_addr)
             .await
-            .expect("Could not open a tunnel to api.secureadsb.com");
+            .map_err(|error| {
+                BoxError::from(format!(
+                    "Could not open a tunnel to api.secureadsb.com: {error}"
+                ))
+            })?;
 
-        TunnelStream::new(tunnel, tunnel_rx)
+        Ok(TunnelStream::new(tunnel, tunnel_rx))
     }
 }
 
@@ -426,11 +504,17 @@ pub struct ProxyCommand {
 }
 
 impl ProxyCommand {
-    pub fn new(command: &mut Command) -> Self {
-        let mut command = command.spawn().expect("failed to spawn");
-        let stdin = command.stdin.take().expect("failed to open stdin");
-        let stdout = command.stdout.take().expect("failed to open stdout");
-        ProxyCommand { stdin, stdout }
+    pub fn new(command: &mut Command) -> Result<Self, BoxError> {
+        let mut command = command.spawn().map_err(|error| {
+            BoxError::from(format!("Failed to spawn SSH ProxyCommand: {error}"))
+        })?;
+        let stdin = command.stdin.take().ok_or_else(|| {
+            BoxError::from("SSH ProxyCommand did not provide stdin")
+        })?;
+        let stdout = command.stdout.take().ok_or_else(|| {
+            BoxError::from("SSH ProxyCommand did not provide stdout")
+        })?;
+        Ok(ProxyCommand { stdin, stdout })
     }
 }
 


### PR DESCRIPTION
Closes #534

## Summary
- Add a bounded in-memory source-health and diagnostic-event store for interactive mode.
- Show compact colored source counts in the aircraft table’s bottom-left border title; retain the aircraft count on the right.
- Add an error overlay: `e` opens it, `Esc` closes it, and `J`/`K` scroll it.
- Track Beast source lifecycle as connecting, healthy, reconnecting, or failed; retain diagnostics after exit for non-interactive runs.
- Make SSH tunnel/configuration failures recoverable and honor parsed `ProxyJump`, allowing Delft and Palaiseau feeds to reconnect successfully.
- Restore the terminal reliably after TUI teardown or a panic, without failing startup when terminal clear probing times out.

## Validation
- `cargo test --all-features`
- `cargo build --release --all-features`
- Manually verified live data from Delft and Palaiseau via `midnight_tunisia`.