### PR TITLE
fix(jet1090): reconnect live SDR sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +834,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,9 +1399,8 @@ dependencies = [
 [[package]]
 name = "desperado"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5eca4e77dafb9389d12160b079e99e5b018ff0914e09efc0b74e6e3a7657bb"
 dependencies = [
+ "async-compression",
  "biquad",
  "dirs",
  "futures",
@@ -1385,6 +1413,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -4081,8 +4110,6 @@ dependencies = [
 [[package]]
 name = "rs-hackrf"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affa4ab24c6d4463c8ca53272ebf5ecacda5739df891be62459bd10d943bb49d"
 dependencies = [
  "nusb",
  "thiserror 2.0.18",
@@ -4092,8 +4119,6 @@ dependencies = [
 [[package]]
 name = "rs-rtl"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14d2eb2473e57beeefdcdca0d7cbc51c5f312e0a9c96ff6374393d5ff4b54b1"
 dependencies = [
  "nusb",
  "thiserror 2.0.18",
@@ -4103,8 +4128,6 @@ dependencies = [
 [[package]]
 name = "rs-spy"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3b1c25996092982f9f8316df5922fb52f85a8ee3c119cce9748d001843db95"
 dependencies = [
  "num-complex",
  "nusb",

--- a/crates/jet1090/Cargo.toml
+++ b/crates/jet1090/Cargo.toml
@@ -28,7 +28,7 @@ clap_complete = "4.6.3"
 clap_complete_nushell = "4.5.10"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 deku = "0.20.3"
-desperado = { version = "0.4.2", optional = true }
+desperado = { version = "0.4.2", path = "../../../desperado/crates/desperado", optional = true }
 dirs = "6.0.0"
 dotenv = "0.15.0"
 futures = "0.3.31"

--- a/crates/jet1090/src/main.rs
+++ b/crates/jet1090/src/main.rs
@@ -12,10 +12,10 @@ mod tui;
 mod util;
 mod web;
 
+use crate::health::SharedHealth;
 use crate::tui::Event;
 use crate::util::expanduser;
 use crate::web::serve_web_api;
-use crate::{health::SharedHealth, health::SourceStatus};
 use clap::{Command, CommandFactory, Parser, ValueHint};
 use clap_complete::{generate, Generator};
 use crossterm::event::KeyCode;
@@ -648,11 +648,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .clone()
             .unwrap_or_else(|| format!("source-{serial:016x}"));
         health::register_source(&health, source_label.clone());
-        health::set_source_status(
-            &health,
-            &source_label,
-            SourceStatus::Healthy,
-        );
         let shutdown_rx = shutdown_tx.subscribe();
         let handle = source.receiver(
             tx_copy,

--- a/crates/jet1090/src/source.rs
+++ b/crates/jet1090/src/source.rs
@@ -46,7 +46,9 @@ use desperado::IqAsyncSource;
 use desperado::{GainElement, GainElementName};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::Sender;
-use tracing::error;
+#[cfg(feature = "sdr")]
+use tokio::time::{sleep, Duration};
+use tracing::{error, warn};
 use url::Url;
 
 use crate::health::{self, SharedHealth, SourceStatus};
@@ -60,6 +62,110 @@ const RATE_6M: f64 = 6.0e6;
 
 #[cfg(feature = "rtlsdr")]
 const RTLSDR_GAIN: f64 = 49.6;
+
+#[cfg(any(
+    feature = "rtlsdr",
+    feature = "soapy",
+    feature = "hackrf",
+    feature = "airspy"
+))]
+const SDR_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+#[cfg(any(
+    feature = "rtlsdr",
+    feature = "soapy",
+    feature = "hackrf",
+    feature = "airspy"
+))]
+const SDR_MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+#[cfg(any(
+    feature = "rtlsdr",
+    feature = "soapy",
+    feature = "hackrf",
+    feature = "airspy"
+))]
+#[allow(clippy::too_many_arguments)]
+async fn supervise_sdr(
+    config: DeviceConfig,
+    tx: Sender<TimedMessage>,
+    serial: u64,
+    rate: f64,
+    name: Option<String>,
+    mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
+    health: SharedHealth,
+    source_label: String,
+) {
+    let mut backoff = SDR_INITIAL_BACKOFF;
+    let mut first_attempt = true;
+
+    loop {
+        health::set_source_status(
+            &health,
+            &source_label,
+            if first_attempt {
+                SourceStatus::Connecting
+            } else {
+                SourceStatus::Reconnecting
+            },
+        );
+        first_attempt = false;
+
+        let source = tokio::select! {
+            result = IqAsyncSource::from_device_config(&config) => result,
+            _ = shutdown_rx.recv() => return,
+        };
+        let source = match source {
+            Ok(source) => {
+                health::set_source_status(
+                    &health,
+                    &source_label,
+                    SourceStatus::Healthy,
+                );
+                source
+            }
+            Err(error) => {
+                health::set_source_status(
+                    &health,
+                    &source_label,
+                    SourceStatus::Reconnecting,
+                );
+                warn!(source = source_label, error = %error, "Failed to open SDR source; retrying in {backoff:?}");
+                tokio::select! {
+                    _ = sleep(backoff) => {},
+                    _ = shutdown_rx.recv() => return,
+                }
+                backoff = (backoff * 2).min(SDR_MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        let mut source = source;
+        let outcome = tokio::select! {
+            result = iqread::receiver(tx.clone(), &mut source, serial, rate, name.clone()) => Some(result),
+            _ = shutdown_rx.recv() => None,
+        };
+        if let Err(error) = source.stop().await {
+            warn!(source = source_label, error = %error, "Failed to stop SDR source cleanly");
+        }
+        let Some(outcome) = outcome else { return };
+        match outcome {
+            Ok(()) => return,
+            Err(error) => {
+                health::set_source_status(
+                    &health,
+                    &source_label,
+                    SourceStatus::Reconnecting,
+                );
+                warn!(source = source_label, error = %error, "SDR stream ended; retrying in {backoff:?}");
+                tokio::select! {
+                    _ = sleep(backoff) => {},
+                    _ = shutdown_rx.recv() => return,
+                }
+                backoff = (backoff * 2).min(SDR_MAX_BACKOFF);
+            }
+        }
+    }
+}
 
 /**
 * A structure to describe the endpoint to access data.
@@ -707,27 +813,24 @@ impl Source {
                 // Use bias_tee from config or default to false
                 let bias_tee = self.bias_tee.unwrap_or(false);
 
-                tokio::spawn(async move {
-                    let rtlsdr_config = RtlSdrConfig {
-                        device,
-                        center_freq: MODES_FREQ as u32,
-                        sample_rate: sample_rate as u32,
-                        gain,
-                        bias_tee,
-                        freq_correction_ppm: 0,
-                    };
-                    let config = DeviceConfig::RtlSdr(rtlsdr_config);
-                    let source = IqAsyncSource::from_device_config(&config)
-                        .await
-                        .expect("Failed to create RTL-SDR source");
-
-                    tokio::select! {
-                        _ = iqread::receiver(tx, source, serial, sample_rate, name) => {},
-                        _ = shutdown_rx.recv() => {
-                            // Silent shutdown
-                        }
-                    }
-                })
+                let config = DeviceConfig::RtlSdr(RtlSdrConfig {
+                    device,
+                    center_freq: MODES_FREQ as u32,
+                    sample_rate: sample_rate as u32,
+                    gain,
+                    bias_tee,
+                    freq_correction_ppm: 0,
+                });
+                tokio::spawn(supervise_sdr(
+                    config,
+                    tx,
+                    serial,
+                    sample_rate,
+                    name,
+                    shutdown_rx,
+                    health,
+                    source_label,
+                ))
             }
             #[cfg(feature = "airspy")]
             Address::Airspy(path) => {
@@ -755,34 +858,28 @@ impl Source {
                 let mixer_gain = config.mixer_gain;
                 let vga_gain = config.vga_gain;
 
-                tokio::spawn(async move {
-                    let airspy_config = AirspyConfig {
-                        device,
-                        center_freq: MODES_FREQ as u32,
-                        sample_rate: sample_rate as u32,
-                        gain,
-                        bias_tee,
-                        packing: false,
-                        lna_gain,
-                        mixer_gain,
-                        vga_gain,
-                        gain_mode: AirspyGainMode::Sensitivity,
-                    };
-
-                    let source = IqAsyncSource::Airspy(
-                        desperado::airspy::AsyncAirspySdrReader::new(
-                            &airspy_config,
-                        )
-                        .expect("Failed to create Airspy source"),
-                    );
-
-                    tokio::select! {
-                        _ = iqread::receiver(tx, source, serial, sample_rate, name) => {},
-                        _ = shutdown_rx.recv() => {
-                            // Silent shutdown
-                        }
-                    }
-                })
+                let config = DeviceConfig::Airspy(AirspyConfig {
+                    device,
+                    center_freq: MODES_FREQ as u32,
+                    sample_rate: sample_rate as u32,
+                    gain,
+                    bias_tee,
+                    packing: false,
+                    lna_gain,
+                    mixer_gain,
+                    vga_gain,
+                    gain_mode: AirspyGainMode::Sensitivity,
+                });
+                tokio::spawn(supervise_sdr(
+                    config,
+                    tx,
+                    serial,
+                    sample_rate,
+                    name,
+                    shutdown_rx,
+                    health,
+                    source_label,
+                ))
             }
             #[cfg(feature = "hackrf")]
             Address::Hackrf(path) => {
@@ -830,29 +927,24 @@ impl Source {
                 let sample_rate = self.sample_rate.unwrap_or(RATE_6M);
                 let bias_tee = self.bias_tee.unwrap_or(false);
 
-                tokio::spawn(async move {
-                    let center_freq = (MODES_FREQ as i64 + freq_offset) as u64;
-                    let hackrf_config = HackRfConfig {
-                        device_index: device_idx,
-                        center_freq,
-                        sample_rate: sample_rate as u32,
-                        gain,
-                        amp_enable,
-                        bias_tee,
-                    };
-
-                    let config = DeviceConfig::HackRf(hackrf_config);
-                    let source = IqAsyncSource::from_device_config(&config)
-                        .await
-                        .expect("Failed to create HackRF source");
-
-                    tokio::select! {
-                        _ = iqread::receiver(tx, source, serial, sample_rate, name) => {},
-                        _ = shutdown_rx.recv() => {
-                            // Silent shutdown
-                        }
-                    }
-                })
+                let config = DeviceConfig::HackRf(HackRfConfig {
+                    device_index: device_idx,
+                    center_freq: (MODES_FREQ as i64 + freq_offset) as u64,
+                    sample_rate: sample_rate as u32,
+                    gain,
+                    amp_enable,
+                    bias_tee,
+                });
+                tokio::spawn(supervise_sdr(
+                    config,
+                    tx,
+                    serial,
+                    sample_rate,
+                    name,
+                    shutdown_rx,
+                    health,
+                    source_label,
+                ))
             }
             #[cfg(feature = "soapy")]
             Address::Soapy(soapy_path) => {
@@ -865,27 +957,24 @@ impl Source {
                 // Use sample_rate from config or default to 2.4 MS/s
                 let sample_rate = self.sample_rate.unwrap_or(RATE_2_4M);
 
-                tokio::spawn(async move {
-                    let soapy_config = SoapyConfig {
-                        args,
-                        center_freq: MODES_FREQ,
-                        sample_rate,
-                        channel: 0,
-                        gain,
-                        bias_tee,
-                    };
-                    let config = DeviceConfig::Soapy(soapy_config);
-                    let source = IqAsyncSource::from_device_config(&config)
-                        .await
-                        .expect("Failed to create SoapySDR source");
-
-                    tokio::select! {
-                        _ = iqread::receiver(tx, source, serial, sample_rate, name) => {},
-                        _ = shutdown_rx.recv() => {
-                            // Silent shutdown
-                        }
-                    }
-                })
+                let config = DeviceConfig::Soapy(SoapyConfig {
+                    args,
+                    center_freq: MODES_FREQ,
+                    sample_rate,
+                    channel: 0,
+                    gain,
+                    bias_tee,
+                });
+                tokio::spawn(supervise_sdr(
+                    config,
+                    tx,
+                    serial,
+                    sample_rate,
+                    name,
+                    shutdown_rx,
+                    health,
+                    source_label,
+                ))
             }
             #[cfg(feature = "sdr")]
             Address::File(file_path) => {

--- a/crates/rs1090/Cargo.toml
+++ b/crates/rs1090/Cargo.toml
@@ -32,7 +32,7 @@ ansi_term = "0.12.1"
 async-recursion = { version = "1.1.1", optional = true }
 async-stream = "0.3.6"
 bytes = { version = "1.11.0", optional = true }
-desperado = { version = "0.4.2", optional = true }
+desperado = { version = "0.4.2", path = "../../../desperado/crates/desperado", optional = true }
 deku = { version = "0.20.3" }
 dirs = { version = "6.0.0", optional = true }
 futures = "0.3.31"

--- a/crates/rs1090/src/source/iqread.rs
+++ b/crates/rs1090/src/source/iqread.rs
@@ -9,65 +9,67 @@ use crate::source::demod::{convert_f32_to_i16_iq, magnitude_u16};
 
 pub async fn receiver(
     tx: mpsc::Sender<TimedMessage>,
-    mut source: IqAsyncSource,
+    source: &mut IqAsyncSource,
     serial: u64,
     rate: f64,
     name: Option<String>,
-) {
+) -> Result<(), desperado::Error> {
     while let Some(buf) = source.next().await {
-        if let Ok(buf) = buf {
-            // Timestamp buffer arrival to calculate per-message reception times.
-            // Ideally timestamping should occur at hardware read (in desperado), but this
-            // approach adds only ~20-100μs delay vs 54ms error from timestamping after demod.
-            let buffer_arrival_ns = now_in_ns();
-            let buffer_arrival_time = buffer_arrival_ns as f64 * 1e-9;
+        let buf = buf?;
+        // Timestamp buffer arrival to calculate per-message reception times.
+        // Ideally timestamping should occur at hardware read (in desperado), but this
+        // approach adds only ~20-100μs delay vs 54ms error from timestamping after demod.
+        let buffer_arrival_ns = now_in_ns();
+        let buffer_arrival_time = buffer_arrival_ns as f64 * 1e-9;
 
-            let resulting_data = match rate {
-                2.4e6 => {
-                    let mag_u16 = magnitude_u16(&buf);
-                    demodulate2400(&mag_u16)
-                }
-                6.0e6 => {
-                    let iq_i16 = convert_f32_to_i16_iq(&buf);
-                    demodulate6000(&iq_i16)
-                }
-                _ => {
-                    panic!(
-                        "Unsupported sample rate: {} (supported: 2.4e6, 6.0e6)",
-                        rate
-                    );
-                }
+        let resulting_data = match rate {
+            2.4e6 => {
+                let mag_u16 = magnitude_u16(&buf);
+                demodulate2400(&mag_u16)
+            }
+            6.0e6 => {
+                let iq_i16 = convert_f32_to_i16_iq(&buf);
+                demodulate6000(&iq_i16)
+            }
+            _ => {
+                return Err(desperado::Error::other(format!(
+                    "Unsupported sample rate: {rate} (supported: 2.4e6, 6.0e6)"
+                )));
+            }
+        };
+
+        for data in resulting_data {
+            // Calculate when this message was received based on its sample position.
+            // Earlier samples (position 0) are older, so subtract offset from buffer arrival.
+            // Note: Uses nominal sample rate; SDR clock drift (±1-2ppm) accumulates over time.
+            let sample_offset_seconds = data.sample_position as f64 / rate;
+            let system_timestamp = buffer_arrival_time - sample_offset_seconds;
+
+            let metadata = SensorMetadata {
+                system_timestamp,
+                gnss_timestamp: None,
+                nanoseconds: None,
+                rssi: Some(10. * data.signal_level.log10() as f32),
+                serial,
+                name: name.clone(),
             };
-
-            for data in resulting_data {
-                // Calculate when this message was received based on its sample position.
-                // Earlier samples (position 0) are older, so subtract offset from buffer arrival.
-                // Note: Uses nominal sample rate; SDR clock drift (±1-2ppm) accumulates over time.
-                let sample_offset_seconds = data.sample_position as f64 / rate;
-                let system_timestamp =
-                    buffer_arrival_time - sample_offset_seconds;
-
-                let metadata = SensorMetadata {
-                    system_timestamp,
-                    gnss_timestamp: None,
-                    nanoseconds: None,
-                    rssi: Some(10. * data.signal_level.log10() as f32),
-                    serial,
-                    name: name.clone(),
-                };
-                let tmsg = TimedMessage {
-                    timestamp: system_timestamp,
-                    frame: data.msg.to_vec(),
-                    message: None,
-                    metadata: vec![metadata],
-                    decode_time: None,
-                };
-                if tx.send(tmsg).await.is_err() {
-                    break;
-                }
+            let tmsg = TimedMessage {
+                timestamp: system_timestamp,
+                frame: data.msg.to_vec(),
+                message: None,
+                metadata: vec![metadata],
+                decode_time: None,
+            };
+            if tx.send(tmsg).await.is_err() {
+                return Ok(());
             }
         }
     }
+
+    Err(desperado::Error::stream_terminated(
+        "SDR",
+        "reader ended unexpectedly",
+    ))
 }
 
 /// Receiver for IQ file sources that calculates timestamps based on sample position


### PR DESCRIPTION
Closes #533

## Dependency
Depends on the Desperado 0.5 lifecycle work, including [desperado#50](https://github.com/xoolive/desperado/pull/50). During co-development this branch uses the sibling `../desperado` checkout rather than pinning a transient commit.

## Summary
- replace one-shot RTL-SDR, Airspy, HackRF, and SoapySDR tasks with a shared, shutdown-aware reconnect supervisor;
- propagate fallible SDR initialization and terminal IQ stream errors to the source-health dashboard;
- transition sources through Connecting, Healthy, and Reconnecting with capped exponential backoff;
- call `IqAsyncSource::stop().await` on every live-source exit for deterministic cleanup;
- return unsupported live sample rates as errors rather than panicking;
- leave IQ-file EOF as normal completion.

## Validation
- `cargo test --all-features`
- `cargo build --release --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- manually validated reconnect behavior with RTL-SDR, Airspy, and HackRF.

SoapySDR manual validation remains pending.